### PR TITLE
usb_relay_device_enumerate: silencing -Wunused-but-set-variable

### DIFF
--- a/lib/usb_relay_device.h
+++ b/lib/usb_relay_device.h
@@ -70,7 +70,7 @@ It should be called at the end of execution to avoid memory leaks.
 int USBRL_API usb_relay_exit(void);
 
 /** Enumerate the USB Relay Devices.
-@return Pointer to list of usb_relay_device_info
+@return Pointer to list of usb_relay_device_info, NULL if unsuccessful.
         Caller should free it with usb_relay_device_free_enumerate
 */
 pusb_relay_device_info_t USBRL_API usb_relay_device_enumerate(void);

--- a/lib/usb_relay_lib.c
+++ b/lib/usb_relay_lib.c
@@ -385,6 +385,9 @@ pusb_relay_device_info_t USBRL_API usb_relay_device_enumerate(void)
                       (void*)&ectx,
                       enumfunc);
 
+    if ( ret != 0 )
+      return NULL;
+
     return (pusb_relay_device_info_t)ectx.head;
 }
 


### PR DESCRIPTION

I was building usb-relay-hid on my machine and ran into this warning:

> ../../lib/usb_relay_lib.c: In function ‘usb_relay_device_enumerate’:
> ../../lib/usb_relay_lib.c:382:9: warning: variable ‘ret’ set but not used [-Wunused-but-set-variable]
>     int ret;
>         ^~~

There is a return code from **usbhidEnumDevices** that is not looked at. 
Since the returning value _pusb_relay_device_info_t_ is a pointer-type, 
I figured if this error appears, NULL is returned.